### PR TITLE
The dispatcher is now passed to Session::getSessionCart()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7
+
+- The dispatcher is now passed to Session::getSessionCart()
+
 # 1.0.3
 
 - Fixed stability tag in module.xml

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <author>
         <name>Julien Chanséaume</name>
         <email>julien@thelia.net</email>

--- a/CustomDelivery.php
+++ b/CustomDelivery.php
@@ -142,7 +142,7 @@ class CustomDelivery extends BaseModule implements DeliveryModuleInterface
     public function isValidDelivery(Country $country)
     {
         // Retrieve the cart
-        $cart = $this->getRequest()->getSession()->getSessionCart();
+        $cart = $this->getRequest()->getSession()->getSessionCart($this->getDispatcher());
 
         /** @var CustomDeliverySlice $slice */
         $slice = $this->getSlicePostage($cart, $country);
@@ -254,7 +254,7 @@ class CustomDelivery extends BaseModule implements DeliveryModuleInterface
     public function getPostage(Country $country)
     {
         $areaId = $country->getAreaId();
-        $cart = $this->getRequest()->getSession()->getSessionCart();
+        $cart = $this->getRequest()->getSession()->getSessionCart($this->getDispatcher());
 
         /** @var CustomDeliverySlice $slice */
         $postage = $this->getSlicePostage($cart, $country);


### PR DESCRIPTION
This prevent problems when the dispatcher was not previously set in the Session object.